### PR TITLE
Add optional support for vagrant-cachier plugin

### DIFF
--- a/docs/fdroid.texi
+++ b/docs/fdroid.texi
@@ -116,6 +116,8 @@ Ruby (debian packages ruby and rubygems)
 Vagrant (unpackaged) Be sure to use 1.3.x because 1.4.x is completely broken
 (at the time of writing, the forthcoming 1.4.3 might work)
 @item
+vagrant-cachier plugin (unpackaged): `vagrant plugin install vagrant-cachier`
+@item
 Paramiko (debian package python-paramiko)
 @item
 Imaging (debian package python-imaging)

--- a/makebuildserver
+++ b/makebuildserver
@@ -146,6 +146,10 @@ for f, src, shasum in cachefiles:
 vagrantfile = """
 Vagrant::Config.run do |config|
 
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
+  end
+
   config.vm.box = "{0}"
   config.vm.box_url = "{1}"
 


### PR DESCRIPTION
Building the basebox is excruciating for people on slow connections. I'm particularly sensitive to this after living in Central America for awhile :)

This won't affect anyone who hasn't installed the plugin. For those who do, it creates a persistent shared folder for each box (ie. testing23.box) and detects directories to cache between VM builds (apt, gems, pip, chef cache, etc.)

(The only downside is that, for those following server setup does who are not aware what vagrant-cachier does, it might be unexpected that artifacts persist between vagrant destroys.)
